### PR TITLE
Update Zotero compatibility to 9.0.* and bump version to 5.0.2

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Autotag",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Automatically assign tags to papers using LLMs.",
   "homepage_url": "https://github.com/LilyKun064/Autotag_zotero_plugin",
   "author": "Chenkun (CJ) Jiang",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -5,7 +5,6 @@
   "description": "Automatically assign tags to papers using LLMs.",
   "homepage_url": "https://github.com/LilyKun064/Autotag_zotero_plugin",
   "author": "Chenkun (CJ) Jiang",
-
   "chrome": {
     "content": [
       {
@@ -14,19 +13,15 @@
       }
     ]
   },
-
   "icons": {
     "48": "content/icons/Jesse.png",
     "96": "content/icons/Jesse.png"
   },
-
   "applications": {
     "zotero": {
       "id": "autotag@LilyKun064",
       "strict_min_version": "6.999",
-      "strict_max_version": "8.0.*"
+      "strict_max_version": "9.0.*"
     }
   }
 }
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-autotag",
-  "version": "3.1.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-autotag",
-      "version": "3.1.1",
+      "version": "5.0.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "zotero-plugin-toolkit": "5.1.0-beta.13"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zotero-autotag",
   "type": "module",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Autotag – Automatically assign tags to Zotero items using LLMs.",
 
   "config": {


### PR DESCRIPTION
Problem

The plugin could not be installed in Zotero 9.0.3 because addon/manifest.json declared strict_max_version: "8.0.*", which excluded Zotero 9 from the supported range.

Changes

Updated strict_max_version in addon/manifest.json from 8.0.* to 9.0.*
Bumped version from 5.0.1 to 5.0.2 in:
package.json
package-lock.json
addon/manifest.json
Verification

Build completed successfully (npm run build)
Generated XPI (.scaffold/build/autotag-5.0.2.xpi) contains:
version: 5.0.2
strict_max_version: 9.0.*
This change allows Zotero 9.0.3 users to install the plugin without compatibility errors.