### PR TITLE
Fix menu integration for Zotero 9, add OpenRouter provider, and fix custom model display

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Release
+        run: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,14 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Release
-        run: npm run release
+      - name: Get version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: .scaffold/build/autotag-${{ steps.version.outputs.version }}.xpi
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ It is built for people who rely on Zotero every day and have reached the point w
 ---
 ## What's NEW
 
-### As of March 26, 2026: 
+### As of May 2026 (v5.0.5):
+Autotag now supports **Zotero 9.0.x** with improved menu integration and:
+- **OpenRouter** as a new LLM provider, giving access to models from Anthropic, OpenAI, Google, DeepSeek, and more
+- Fixed custom model display in settings and success messages
+- Improved API key configuration for all providers
+- Menu items now reliably appear in Zotero 9 Tools menu
+
+### Previous Update (v4.0.2):
 Autotag 4.0.2 now allows you to: 
 - choose what info to be uploaded to LLM
 - include full-text pdf for better tags
@@ -33,6 +40,9 @@ You can now choose between:
 
 - DeepSeek
     Use DeepSeek models for strong reasoning focused tagging.
+
+- OpenRouter
+    Access a wide variety of models from Anthropic, OpenAI, Google, DeepSeek, and other providers through a single API key.
 
 - Local LLMs via Ollama
     Run tagging completely offline using local models such as LLaMA, Mistral, or Qwen through Ollama.
@@ -76,6 +86,8 @@ It exists to **remove the burden of manual tagging** while keeping everything in
 4. Choose the downloaded .xpi
 
 5. Restart Zotero.
+
+**Compatibility:** Works with Zotero 6.999 through 9.0.x
 
 ## Setting Up
 

--- a/addon/locale/en-US/mainWindow.ftl
+++ b/addon/locale/en-US/mainWindow.ftl
@@ -9,3 +9,8 @@ item-section-example2-sidenav-tooltip =
 item-section-example2-button-tooltip =
     .tooltiptext = Unregister this section
 item-info-row-example-label = Example Row
+
+autotag-settings-menu =
+    .label = Autotag: settings…
+autotag-run-menu =
+    .label = Autotag: tag selected items

--- a/addon/locale/zh-CN/mainWindow.ftl
+++ b/addon/locale/zh-CN/mainWindow.ftl
@@ -9,3 +9,8 @@ item-section-example2-sidenav-tooltip =
 item-section-example2-button-tooltip =
     .tooltiptext = 移除此面板
 item-info-row-example-label = 示例行
+
+autotag-settings-menu =
+    .label = Autotag: 设置…
+autotag-run-menu =
+    .label = Autotag: 标记选中条目

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Autotag",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Automatically assign tags to papers using LLMs.",
   "homepage_url": "https://github.com/LilyKun064/Autotag_zotero_plugin",
   "author": "Chenkun (CJ) Jiang",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Autotag",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Automatically assign tags to papers using LLMs.",
   "homepage_url": "https://github.com/LilyKun064/Autotag_zotero_plugin",
   "author": "Chenkun (CJ) Jiang",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Autotag",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Automatically assign tags to papers using LLMs.",
   "homepage_url": "https://github.com/LilyKun064/Autotag_zotero_plugin",
   "author": "Chenkun (CJ) Jiang",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Autotag",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Automatically assign tags to papers using LLMs.",
   "homepage_url": "https://github.com/LilyKun064/Autotag_zotero_plugin",
   "author": "Chenkun (CJ) Jiang",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -5,7 +5,6 @@
   "description": "Automatically assign tags to papers using LLMs.",
   "homepage_url": "https://github.com/LilyKun064/Autotag_zotero_plugin",
   "author": "Chenkun (CJ) Jiang",
-
   "chrome": {
     "content": [
       {
@@ -14,19 +13,15 @@
       }
     ]
   },
-
   "icons": {
     "48": "content/icons/Jesse.png",
     "96": "content/icons/Jesse.png"
   },
-
   "applications": {
     "zotero": {
       "id": "autotag@LilyKun064",
       "strict_min_version": "6.999",
-      "strict_max_version": "8.0.*"
+      "strict_max_version": "9.0.*"
     }
   }
 }
-
-

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,6 +1,11 @@
 pref("enable", true);
 pref("input", "This is input");
 
+pref("apiKey.openai", "");
+pref("apiKey.gemini", "");
+pref("apiKey.deepseek", "");
+pref("apiKey.openrouter", "");
+
 pref("baseURL.openai", "");
 pref("customModel.openai", "");
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -6,3 +6,6 @@ pref("customModel.openai", "");
 
 pref("baseURL.deepseek", "");
 pref("customModel.deepseek", "");
+
+pref("baseURL.openrouter", "");
+pref("customModel.openrouter", "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-autotag",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-autotag",
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "zotero-plugin-toolkit": "5.1.0-beta.13"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-autotag",
-  "version": "3.1.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-autotag",
-      "version": "3.1.1",
+      "version": "5.0.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "zotero-plugin-toolkit": "5.1.0-beta.13"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-autotag",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-autotag",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "zotero-plugin-toolkit": "5.1.0-beta.13"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zotero-autotag",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zotero-autotag",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "zotero-plugin-toolkit": "5.1.0-beta.13"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "zotero-autotag",
   "type": "module",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Autotag – Automatically assign tags to Zotero items using LLMs.",
-
   "config": {
     "addonName": "Autotag",
     "addonID": "autotag@LilyKun064",
@@ -11,20 +10,16 @@
     "addonInstance": "Autotag",
     "prefsPrefix": "extensions.zotero.autotag"
   },
-
   "repository": {
     "type": "git",
     "url": "git+https://github.com/LilyKun064/zotero_autotagging.git"
   },
-
   "author": "Chenkun (CJ) Jiang",
   "homepage": "https://github.com/LilyKun064/zotero_autotagging#readme",
   "bugs": {
     "url": "https://github.com/LilyKun064/zotero_autotagging/issues"
   },
-
   "license": "AGPL-3.0-or-later",
-
   "scripts": {
     "start": "zotero-plugin serve",
     "build": "zotero-plugin build && tsc --noEmit",
@@ -35,11 +30,9 @@
     "test": "zotero-plugin test",
     "update-deps": "npm update --save"
   },
-
   "dependencies": {
     "zotero-plugin-toolkit": "5.1.0-beta.13"
   },
-
   "devDependencies": {
     "@types/chai": "^5.2.2",
     "@types/mocha": "^10.0.10",
@@ -53,14 +46,15 @@
     "zotero-plugin-scaffold": "^0.8.1",
     "zotero-types": "^4.1.0-beta.4"
   },
-
   "prettier": {
     "printWidth": 80,
     "tabWidth": 2,
     "endOfLine": "lf",
     "overrides": [
       {
-        "files": ["*.xhtml"],
+        "files": [
+          "*.xhtml"
+        ],
         "options": {
           "htmlWhitespaceSensitivity": "css"
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zotero-autotag",
   "type": "module",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Autotag – Automatically assign tags to Zotero items using LLMs.",
 
   "config": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zotero-autotag",
   "type": "module",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Autotag – Automatically assign tags to Zotero items using LLMs.",
   "config": {
     "addonName": "Autotag",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zotero-autotag",
   "type": "module",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Autotag – Automatically assign tags to Zotero items using LLMs.",
   "config": {
     "addonName": "Autotag",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -12,6 +12,7 @@ import {
   openAutotagSettings,
   getPromptContentOptions,
 } from "./modules/autotagPrefs";
+import { registerAutotagToolsMenu } from "./modules/autotagMenu";
 import { config } from "../package.json";
 
 type ItemMetadata = {
@@ -198,96 +199,9 @@ async function onStartup(): Promise<void> {
     Zotero.uiReadyPromise,
   ]);
 
-  // Register menus using Zotero.MenuManager API (Zotero 8+)
-  try {
-    (Zotero as any).MenuManager.registerMenu({
-      menuType: "menuitem",
-      target: "main/menubar/tools",
-      l10nID: "autotag-settings-menu",
-      onCommand: () => {
-        try {
-          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
-          openAutotagSettings(win);
-        } catch (e) {
-          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
-          showError(win, "Autotag settings failed", e);
-        }
-      },
-      menuID: "autotag-settings-menu",
-      pluginID: config.addonID,
-    });
-
-    (Zotero as any).MenuManager.registerMenu({
-      menuType: "menuitem",
-      target: "main/menubar/tools",
-      l10nID: "autotag-run-menu",
-      onCommand: async () => {
-        try {
-          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
-          const pane =
-            (Zotero as any).getActiveZoteroPane?.() ||
-            (Zotero as any).Pane?.getActive?.();
-
-          if (!pane) {
-            (win as any).alert("Autotag: No active Zotero pane found.");
-            return;
-          }
-
-          const selectedItems = pane.getSelectedItems?.() || [];
-          if (!selectedItems.length) {
-            (win as any).alert("Autotag: No items selected.");
-            return;
-          }
-
-          const provider = getSelectedProvider();
-
-          // Only check API key for non-local providers
-          if (provider !== "local") {
-            const apiKey = getApiKeyForProvider(provider);
-            if (!apiKey) {
-              const ask =
-                Services?.prompt?.confirm?.(
-                  win,
-                  "Autotag",
-                  "No API key is configured for this provider.\n\n" +
-                  "Would you like to open Autotag settings now?",
-                ) ??
-                (win as any).confirm(
-                  "Autotag\n\nNo API key is configured for this provider.\n\n" +
-                  "Would you like to open Autotag settings now?",
-                );
-
-              if (ask) {
-                try {
-                  openAutotagSettings(win);
-                } catch (e) {
-                  showError(win, "Autotag settings failed", e);
-                }
-              }
-              return;
-            }
-          }
-
-          // Build payload asynchronously because PDF extraction can be async
-          const payload: ItemMetadata[] = [];
-          for (const item of selectedItems) {
-            payload.push(await getItemMetadata(item));
-          }
-
-          await runAutotagForItems(payload, win);
-        } catch (e) {
-          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
-          showError(win, "Autotag run failed", e);
-        }
-      },
-      menuID: "autotag-run-menu",
-      pluginID: config.addonID,
-    });
-
-    debug("Autotag: menus registered using Zotero.MenuManager");
-  } catch (e) {
-    debug("Autotag: failed to register menus: " + String(e));
-  }
+  // Menu registration moved to onMainWindowLoad using manual insertion
+  // (Zotero.MenuManager.registerMenu was unreliable in Zotero 9)
+  debug("Autotag: startup complete, menu registration will happen per window");
 
   // Register for all existing main windows
   const wins = Zotero.getMainWindows() as _ZoteroTypes.MainWindow[];
@@ -303,7 +217,7 @@ async function onMainWindowLoad(
   win: _ZoteroTypes.MainWindow,
 ): Promise<void> {
   injectAutotagStyles(win);  // Inject CSS into window
-  // Menus are now registered via Zotero.MenuManager in onStartup
+  registerAutotagToolsMenu(win);  // Insert menu items into Tools menu
 }
 
 /**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,7 +4,167 @@
 // Zotero global from the app
 declare const Zotero: _ZoteroTypes.Zotero;
 
-import { registerAutotagToolsMenu } from "./modules/autotagMenu";
+import { runAutotagForItems } from "./modules/autotagCore";
+import {
+  Services,
+  getSelectedProvider,
+  getApiKeyForProvider,
+  openAutotagSettings,
+  getPromptContentOptions,
+} from "./modules/autotagPrefs";
+import { config } from "../package.json";
+
+type ItemMetadata = {
+  key: string;
+  itemType: string;
+  title: string;
+  abstract: string;
+  publicationTitle: string;
+  date: string;
+  creators: string[];
+  tags: string[];
+  pdfText?: string;
+};
+
+function debug(msg: string) {
+  (Zotero as any).debug?.(msg);
+}
+
+function showError(win: _ZoteroTypes.MainWindow, title: string, e: unknown) {
+  const err = e instanceof Error ? e : new Error(String(e));
+  const message = err.message || String(e);
+  const stack = err.stack || "";
+
+  debug(`Autotag: ${title}: ${message}\n${stack}`);
+
+  try {
+    (Zotero as any).logError?.(err);
+  } catch {
+    // ignore
+  }
+
+  const detail = stack && !stack.includes(message)
+    ? `${message}\n\n${stack}`
+    : message;
+
+  (win as any).alert(`${title}\n\n${detail}`);
+}
+
+function normalizeExtractedText(text: string): string {
+  return String(text || "")
+    .split("\x00").join(" ")
+    .replace(/\r/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+}
+
+function truncatePdfText(text: string): string {
+  const options = getPromptContentOptions();
+  const cleaned = normalizeExtractedText(text);
+
+  if (!cleaned) return "";
+
+  if (options.pdfTextMode === "full_text") {
+    return cleaned;
+  }
+
+  const limit =
+    Number.isFinite(options.pdfTextCharLimit) && options.pdfTextCharLimit > 0
+      ? Math.floor(options.pdfTextCharLimit)
+      : 4000;
+
+  if (cleaned.length <= limit) return cleaned;
+  return cleaned.slice(0, limit).trim();
+}
+
+async function getExtractedAttachmentTextForItem(item: any): Promise<string> {
+  try {
+    if (item?.isAttachment?.()) {
+      const contentType = String(item.attachmentContentType || "").toLowerCase();
+      if (contentType === "application/pdf" || contentType === "text/html") {
+        const text = await item.attachmentText;
+        return truncatePdfText(String(text || ""));
+      }
+      return "";
+    }
+
+    if (!item?.isRegularItem?.()) {
+      return "";
+    }
+
+    const attachmentIDs = item.getAttachments?.() || [];
+    if (!attachmentIDs.length) return "";
+
+    const attachments = attachmentIDs
+      .map((id: number) => {
+        try {
+          return Zotero.Items.get(id);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    if (!attachments.length) return "";
+
+    const importedPdf = attachments.find((att: any) => {
+      const ct = String(att?.attachmentContentType || "").toLowerCase();
+      return ct === "application/pdf" && !!att?.isImportedAttachment?.();
+    });
+
+    const anyPdf = attachments.find((att: any) => {
+      const ct = String(att?.attachmentContentType || "").toLowerCase();
+      return ct === "application/pdf";
+    });
+
+    const htmlAttachment = attachments.find((att: any) => {
+      const ct = String(att?.attachmentContentType || "").toLowerCase();
+      return ct === "text/html";
+    });
+
+    const chosen = importedPdf || anyPdf || htmlAttachment;
+    if (!chosen) return "";
+
+    try {
+      const text = await chosen.attachmentText;
+      return truncatePdfText(String(text || ""));
+    } catch (e) {
+      debug(`Autotag: failed to read attachment text for item ${item.key}: ${String(e)}`);
+      return "";
+    }
+  } catch (e) {
+    debug(`Autotag: getExtractedAttachmentTextForItem failed for ${item?.key || "[unknown]"}: ${String(e)}`);
+    return "";
+  }
+}
+
+async function getItemMetadata(item: any): Promise<ItemMetadata> {
+  const creators = (item.getCreators?.() || []).map((c: any) => {
+    if (c.lastName && c.firstName) return `${c.lastName}, ${c.firstName}`;
+    return c.name || c.lastName || "[unknown creator]";
+  });
+
+  const tags = (item.getTags?.() || []).map((t: any) => t.tag);
+  const options = getPromptContentOptions();
+
+  let pdfText = "";
+  if (options.includePdfText) {
+    pdfText = await getExtractedAttachmentTextForItem(item);
+  }
+
+  return {
+    key: item.key,
+    itemType: item.itemType,
+    title: item.getField?.("title") || "",
+    abstract: item.getField?.("abstractNote") || "",
+    publicationTitle: item.getField?.("publicationTitle") || "",
+    date: item.getField?.("date") || "",
+    creators,
+    tags,
+    pdfText: pdfText || "",
+  };
+}
 
 /**
  * Inject our CSS into the Zotero main window.
@@ -38,6 +198,97 @@ async function onStartup(): Promise<void> {
     Zotero.uiReadyPromise,
   ]);
 
+  // Register menus using Zotero.MenuManager API (Zotero 8+)
+  try {
+    (Zotero as any).MenuManager.registerMenu({
+      menuType: "menuitem",
+      target: "main/menubar/tools",
+      l10nID: "autotag-settings-menu",
+      onCommand: () => {
+        try {
+          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
+          openAutotagSettings(win);
+        } catch (e) {
+          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
+          showError(win, "Autotag settings failed", e);
+        }
+      },
+      menuID: "autotag-settings-menu",
+      pluginID: config.addonID,
+    });
+
+    (Zotero as any).MenuManager.registerMenu({
+      menuType: "menuitem",
+      target: "main/menubar/tools",
+      l10nID: "autotag-run-menu",
+      onCommand: async () => {
+        try {
+          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
+          const pane =
+            (Zotero as any).getActiveZoteroPane?.() ||
+            (Zotero as any).Pane?.getActive?.();
+
+          if (!pane) {
+            (win as any).alert("Autotag: No active Zotero pane found.");
+            return;
+          }
+
+          const selectedItems = pane.getSelectedItems?.() || [];
+          if (!selectedItems.length) {
+            (win as any).alert("Autotag: No items selected.");
+            return;
+          }
+
+          const provider = getSelectedProvider();
+
+          // Only check API key for non-local providers
+          if (provider !== "local") {
+            const apiKey = getApiKeyForProvider(provider);
+            if (!apiKey) {
+              const ask =
+                Services?.prompt?.confirm?.(
+                  win,
+                  "Autotag",
+                  "No API key is configured for this provider.\n\n" +
+                  "Would you like to open Autotag settings now?",
+                ) ??
+                (win as any).confirm(
+                  "Autotag\n\nNo API key is configured for this provider.\n\n" +
+                  "Would you like to open Autotag settings now?",
+                );
+
+              if (ask) {
+                try {
+                  openAutotagSettings(win);
+                } catch (e) {
+                  showError(win, "Autotag settings failed", e);
+                }
+              }
+              return;
+            }
+          }
+
+          // Build payload asynchronously because PDF extraction can be async
+          const payload: ItemMetadata[] = [];
+          for (const item of selectedItems) {
+            payload.push(await getItemMetadata(item));
+          }
+
+          await runAutotagForItems(payload, win);
+        } catch (e) {
+          const win = Zotero.getMainWindows()[0] as _ZoteroTypes.MainWindow;
+          showError(win, "Autotag run failed", e);
+        }
+      },
+      menuID: "autotag-run-menu",
+      pluginID: config.addonID,
+    });
+
+    debug("Autotag: menus registered using Zotero.MenuManager");
+  } catch (e) {
+    debug("Autotag: failed to register menus: " + String(e));
+  }
+
   // Register for all existing main windows
   const wins = Zotero.getMainWindows() as _ZoteroTypes.MainWindow[];
   for (const win of wins) {
@@ -51,8 +302,8 @@ async function onStartup(): Promise<void> {
 async function onMainWindowLoad(
   win: _ZoteroTypes.MainWindow,
 ): Promise<void> {
-  injectAutotagStyles(win);       // 🔑 make sure CSS is loaded
-  registerAutotagToolsMenu(win);  // 🔑 then create the Tools menu items
+  injectAutotagStyles(win);  // Inject CSS into window
+  // Menus are now registered via Zotero.MenuManager in onStartup
 }
 
 /**

--- a/src/modules/autotagCore.ts
+++ b/src/modules/autotagCore.ts
@@ -10,6 +10,7 @@ import {
   Services as PrefsServices,
   getSeedKeywords,
   getModelForProvider,
+  getCustomModelForProvider,
   getFinalPrompt,
   getPromptContentOptions,
 } from "./autotagPrefs";
@@ -209,7 +210,9 @@ async function callLLMForTags(
   sourceItems: ItemMetadata[],
 ): Promise<LLMTagResult> {
   const provider = getLLMProvider();
-  const model = getModelForProvider(provider.name) || "(default)";
+  const customModel = getCustomModelForProvider(provider.name).trim();
+  const selectedModel = getModelForProvider(provider.name).trim();
+  const model = customModel || selectedModel || "(default)";
 
   let content = "";
 
@@ -230,15 +233,15 @@ async function callLLMForTags(
       const apiVersion = match ? match[1] : "your current API version";
       throw new Error(
         `This model is not supported by the current API version (${apiVersion}).\n\n` +
-          "Please select a different model in Autotag settings.",
+        "Please select a different model in Autotag settings.",
       );
     }
 
     if (msg.includes("404") && msg.toLowerCase().includes("not found")) {
       throw new Error(
         "This model is not available anymore according to the provider.\n\n" +
-          "Please select another model in Autotag settings.\n\n" +
-          "Note: If you're using local model, the model you're calling might not be installed. ",
+        "Please select another model in Autotag settings.\n\n" +
+        "Note: If you're using local model, the model you're calling might not be installed. ",
       );
     }
 
@@ -255,14 +258,14 @@ async function callLLMForTags(
   } catch {
     throw new Error(
       `Invalid JSON returned by ${provider.name} (${model}).\n\n` +
-        `First 1000 chars of raw response:\n${content.substring(0, 1000)}`,
+      `First 1000 chars of raw response:\n${content.substring(0, 1000)}`,
     );
   }
 
   if (!parsed?.items || !Array.isArray(parsed.items)) {
     throw new Error(
       `LLM JSON missing items array (${provider.name}, ${model}).\n\n` +
-        `Returned JSON:\n${JSON.stringify(parsed, null, 2).substring(0, 1000)}`,
+      `Returned JSON:\n${JSON.stringify(parsed, null, 2).substring(0, 1000)}`,
     );
   }
 
@@ -437,7 +440,9 @@ export async function runAutotagForItems(
   }
 
   const provider = getLLMProvider();
-  const model = getModelForProvider(provider.name) || "(default)";
+  const customModel = getCustomModelForProvider(provider.name).trim();
+  const selectedModel = getModelForProvider(provider.name).trim();
+  const model = customModel || selectedModel || "(default)";
   const prompt = buildPromptFromItems(items);
 
   (Zotero as any).debug?.(
@@ -455,7 +460,7 @@ export async function runAutotagForItems(
 
   (Zotero as any).debug?.(
     `Autotag input keys: ${JSON.stringify(inputKeys)}\n` +
-      `Autotag output keys: ${JSON.stringify(outputKeys)}`,
+    `Autotag output keys: ${JSON.stringify(outputKeys)}`,
   );
 
   const edited = previewAndEditTags(llmResult, items, mainWin);

--- a/src/modules/autotagMenu.ts
+++ b/src/modules/autotagMenu.ts
@@ -10,6 +10,7 @@
 declare const Zotero: _ZoteroTypes.Zotero;
 
 import { runAutotagForItems } from "./autotagCore";
+import type { LLMProvider } from "./llmproviders/LLMProvider";
 import {
   Services, // from autotagPrefs (Z8-safe)
   getSelectedProvider,
@@ -17,6 +18,8 @@ import {
   openAutotagSettings,
   getPromptContentOptions,
 } from "./autotagPrefs";
+import { getLLMProvider } from "./llmproviders";
+import { getString } from "../utils/locale";
 
 export type ItemMetadata = {
   key: string;
@@ -259,7 +262,8 @@ export function registerAutotagToolsMenu(win: _ZoteroTypes.MainWindow): void {
      ========================= */
   const settingsItem = xulDoc.createXULElement("menuitem");
   settingsItem.id = "autotag-settings-menuitem";
-  settingsItem.setAttribute("label", "Autotag: settings…");
+  const settingsLabel = getString("autotag-settings-menu") || "Autotag: settings…";
+  settingsItem.setAttribute("label", settingsLabel);
   settingsItem.setAttribute("class", "menuitem-iconic autotag-menuitem");
   settingsItem.removeAttribute("image");
 
@@ -276,7 +280,8 @@ export function registerAutotagToolsMenu(win: _ZoteroTypes.MainWindow): void {
      ========================= */
   const runItem = xulDoc.createXULElement("menuitem");
   runItem.id = "autotag-run-menuitem";
-  runItem.setAttribute("label", "Autotag: tag selected items");
+  const runLabel = getString("autotag-run-menu") || "Autotag: tag selected items";
+  runItem.setAttribute("label", runLabel);
   runItem.setAttribute("class", "menuitem-iconic autotag-menuitem");
   runItem.removeAttribute("image");
 
@@ -308,11 +313,11 @@ export function registerAutotagToolsMenu(win: _ZoteroTypes.MainWindow): void {
               win,
               "Autotag",
               "No API key is configured for this provider.\n\n" +
-                "Would you like to open Autotag settings now?",
+              "Would you like to open Autotag settings now?",
             ) ??
             (win as any).confirm(
               "Autotag\n\nNo API key is configured for this provider.\n\n" +
-                "Would you like to open Autotag settings now?",
+              "Would you like to open Autotag settings now?",
             );
 
           if (ask) {

--- a/src/modules/autotagPrefs.ts
+++ b/src/modules/autotagPrefs.ts
@@ -849,12 +849,17 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
       ? getCustomModelForProvider(provider).trim() || "(none)"
       : "(not applicable)";
 
+  const actualModel =
+    customModelSummary !== "(none)" && customModelSummary !== "(not applicable)"
+      ? customModelSummary
+      : selectedModel || "(unchanged)";
+
   confirmDialog(
     win,
     "Autotag settings saved",
     [
       `Provider: ${provider}`,
-      `Model: ${selectedModel || "(unchanged)"}`,
+      `Model: ${actualModel}`,
       `Custom API Base URL: ${baseUrlSummary}`,
       `Custom Model ID: ${customModelSummary}`,
       "",

--- a/src/modules/autotagPrefs.ts
+++ b/src/modules/autotagPrefs.ts
@@ -606,14 +606,17 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
 
     case "openrouter":
       modelOptions = [
-        "openai/gpt-4o-mini",
+        "anthropic/claude-4.6-sonnet-20260217",
+        "anthropic/claude-4.7-opus-20260416",
         "openai/gpt-4o",
-        "anthropic/claude-3.5-sonnet",
-        "anthropic/claude-3.5-haiku",
-        "google/gemini-pro-1.5",
-        "meta-llama/llama-3.1-70b-instruct",
+        "openai/gpt-4o-mini",
+        "google/gemini-3-flash-preview-20251217",
+        "deepseek/deepseek-v4-flash-20260423",
+        "deepseek/deepseek-v4-pro-20260423",
+        "moonshotai/kimi-k2.6-20260420",
+        "tencent/hy3-preview-20260421",
       ];
-      defaultModel = "openai/gpt-4o-mini";
+      defaultModel = "anthropic/claude-4.6-sonnet-20260217";
       break;
 
     case "local":

--- a/src/modules/autotagPrefs.ts
+++ b/src/modules/autotagPrefs.ts
@@ -37,20 +37,24 @@ const PREF_PROVIDER = `${PREF_BRANCH}llmProvider`;
 const PREF_API_KEY_OPENAI = `${PREF_BRANCH}apiKey.openai`;
 const PREF_API_KEY_GEMINI = `${PREF_BRANCH}apiKey.gemini`;
 const PREF_API_KEY_DEEPSEEK = `${PREF_BRANCH}apiKey.deepseek`;
+const PREF_API_KEY_OPENROUTER = `${PREF_BRANCH}apiKey.openrouter`;
 
 // Models
 const PREF_MODEL_OPENAI = `${PREF_BRANCH}model.openai`;
 const PREF_MODEL_GEMINI = `${PREF_BRANCH}model.gemini`;
 const PREF_MODEL_DEEPSEEK = `${PREF_BRANCH}model.deepseek`;
+const PREF_MODEL_OPENROUTER = `${PREF_BRANCH}model.openrouter`;
 const PREF_MODEL_LOCAL = `${PREF_BRANCH}model.local`;
 
 // Custom base URLs
 const PREF_BASE_URL_OPENAI = `${PREF_BRANCH}baseURL.openai`;
 const PREF_BASE_URL_DEEPSEEK = `${PREF_BRANCH}baseURL.deepseek`;
+const PREF_BASE_URL_OPENROUTER = `${PREF_BRANCH}baseURL.openrouter`;
 
 // Custom model IDs
 const PREF_CUSTOM_MODEL_OPENAI = `${PREF_BRANCH}customModel.openai`;
 const PREF_CUSTOM_MODEL_DEEPSEEK = `${PREF_BRANCH}customModel.deepseek`;
+const PREF_CUSTOM_MODEL_OPENROUTER = `${PREF_BRANCH}customModel.openrouter`;
 
 // Seed keywords
 const PREF_SEED_KEYWORDS = `${PREF_BRANCH}seedKeywords`;
@@ -162,6 +166,8 @@ function getApiKeyPref(provider: string): string {
       return PREF_API_KEY_GEMINI;
     case "deepseek":
       return PREF_API_KEY_DEEPSEEK;
+    case "openrouter":
+      return PREF_API_KEY_OPENROUTER;
     case "openai":
     default:
       return PREF_API_KEY_OPENAI;
@@ -174,6 +180,8 @@ function getModelPref(provider: string): string {
       return PREF_MODEL_GEMINI;
     case "deepseek":
       return PREF_MODEL_DEEPSEEK;
+    case "openrouter":
+      return PREF_MODEL_OPENROUTER;
     case "local":
       return PREF_MODEL_LOCAL;
     case "openai":
@@ -186,6 +194,8 @@ function getBaseUrlPref(provider: string): string {
   switch (provider) {
     case "deepseek":
       return PREF_BASE_URL_DEEPSEEK;
+    case "openrouter":
+      return PREF_BASE_URL_OPENROUTER;
     case "openai":
     default:
       return PREF_BASE_URL_OPENAI;
@@ -196,6 +206,8 @@ function getCustomModelPref(provider: string): string {
   switch (provider) {
     case "deepseek":
       return PREF_CUSTOM_MODEL_DEEPSEEK;
+    case "openrouter":
+      return PREF_CUSTOM_MODEL_OPENROUTER;
     case "openai":
     default:
       return PREF_CUSTOM_MODEL_OPENAI;
@@ -249,7 +261,7 @@ export function setModelForProvider(provider: string, model: string): void {
 // =========================
 
 export function getBaseUrlForProvider(provider: string): string {
-  if (provider !== "openai" && provider !== "deepseek") return "";
+  if (provider !== "openai" && provider !== "deepseek" && provider !== "openrouter") return "";
 
   const prefKey = getBaseUrlPref(provider);
   try {
@@ -261,7 +273,7 @@ export function getBaseUrlForProvider(provider: string): string {
 }
 
 export function setBaseUrlForProvider(provider: string, value: string): void {
-  if (provider !== "openai" && provider !== "deepseek") return;
+  if (provider !== "openai" && provider !== "deepseek" && provider !== "openrouter") return;
 
   const prefKey = getBaseUrlPref(provider);
   Zotero.Prefs.set(prefKey, value, true);
@@ -272,7 +284,7 @@ export function setBaseUrlForProvider(provider: string, value: string): void {
 // =========================
 
 export function getCustomModelForProvider(provider: string): string {
-  if (provider !== "openai" && provider !== "deepseek") return "";
+  if (provider !== "openai" && provider !== "deepseek" && provider !== "openrouter") return "";
 
   const prefKey = getCustomModelPref(provider);
   try {
@@ -284,7 +296,7 @@ export function getCustomModelForProvider(provider: string): string {
 }
 
 export function setCustomModelForProvider(provider: string, value: string): void {
-  if (provider !== "openai" && provider !== "deepseek") return;
+  if (provider !== "openai" && provider !== "deepseek" && provider !== "openrouter") return;
 
   const prefKey = getCustomModelPref(provider);
   Zotero.Prefs.set(prefKey, value, true);
@@ -523,8 +535,8 @@ function yesNoDialog(
 // =========================
 
 export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
-  const providerLabels = ["OpenAI", "Gemini", "DeepSeek", "Local (Ollama)"];
-  const providerValues = ["openai", "gemini", "deepseek", "local"];
+  const providerLabels = ["OpenAI", "Gemini", "DeepSeek", "OpenRouter", "Local (Ollama)"];
+  const providerValues = ["openai", "gemini", "deepseek", "openrouter", "local"];
 
   const currentProvider = getSelectedProvider();
   const providerIndex = Math.max(providerValues.indexOf(currentProvider), 0);
@@ -542,11 +554,13 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
   setSelectedProvider(provider);
 
   // ---------- Optional custom base URL ----------
-  if (provider === "openai" || provider === "deepseek") {
+  if (provider === "openai" || provider === "deepseek" || provider === "openrouter") {
     const defaultBaseUrl =
       provider === "openai"
         ? "https://api.openai.com/v1"
-        : "https://api.deepseek.com/v1";
+        : provider === "deepseek"
+          ? "https://api.deepseek.com/v1"
+          : "https://openrouter.ai/api/v1";
 
     const wantsCustomBaseUrl = yesNoDialog(
       win,
@@ -590,6 +604,18 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
       defaultModel = "deepseek-chat";
       break;
 
+    case "openrouter":
+      modelOptions = [
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o",
+        "anthropic/claude-3.5-sonnet",
+        "anthropic/claude-3.5-haiku",
+        "google/gemini-pro-1.5",
+        "meta-llama/llama-3.1-70b-instruct",
+      ];
+      defaultModel = "openai/gpt-4o-mini";
+      break;
+
     case "local":
       defaultModel = "";
       break;
@@ -609,7 +635,7 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
     selectedModel = raw.trim();
   } else {
     const supportsCustomModel =
-      provider === "openai" || provider === "deepseek";
+      provider === "openai" || provider === "deepseek" || provider === "openrouter";
 
     const modelOptionsWithOther = supportsCustomModel
       ? [...modelOptions, "Other (enter custom model ID)"]
@@ -663,7 +689,7 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
     setModelForProvider(provider, selectedModel);
   }
 
-  if (provider === "openai" || provider === "deepseek") {
+  if (provider === "openai" || provider === "deepseek" || provider === "openrouter") {
     setCustomModelForProvider(provider, selectedCustomModel);
   }
 
@@ -796,7 +822,7 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
     win,
     "Autotag settings",
     "Edit the prompt Autotag sends to the LLM.\n\n" +
-      "This prompt will be reused for all future runs.",
+    "This prompt will be reused for all future runs.",
     getFinalPrompt(),
   );
   if (promptRaw != null) {
@@ -811,12 +837,12 @@ export function openAutotagSettings(win: _ZoteroTypes.MainWindow): void {
     : "disabled";
 
   const baseUrlSummary =
-    provider === "openai" || provider === "deepseek"
+    provider === "openai" || provider === "deepseek" || provider === "openrouter"
       ? getBaseUrlForProvider(provider).trim() || "(default)"
       : "(not applicable)";
 
   const customModelSummary =
-    provider === "openai" || provider === "deepseek"
+    provider === "openai" || provider === "deepseek" || provider === "openrouter"
       ? getCustomModelForProvider(provider).trim() || "(none)"
       : "(not applicable)";
 

--- a/src/modules/llmproviders/index.ts
+++ b/src/modules/llmproviders/index.ts
@@ -3,6 +3,7 @@
 import { OpenAIProvider } from "./openaiProvider";
 import { GeminiProvider } from "./geminiProvider";
 import { DeepSeekProvider } from "./deepseekProvider";
+import { OpenRouterProvider } from "./openrouterProvider";
 import { LocalProvider } from "./localProvider";
 
 import { getSelectedProvider } from "../autotagPrefs";
@@ -15,6 +16,8 @@ export function getLLMProvider() {
       return GeminiProvider;
     case "deepseek":
       return DeepSeekProvider;
+    case "openrouter":
+      return OpenRouterProvider;
     case "local":
       return LocalProvider;
     case "openai":

--- a/src/modules/llmproviders/openrouterProvider.ts
+++ b/src/modules/llmproviders/openrouterProvider.ts
@@ -60,13 +60,9 @@ export const OpenRouterProvider: LLMProvider = {
     };
 
     // Add optional attribution headers (these help with OpenRouter rankings)
-    try {
-      const addonURL = "https://github.com/LilyKun064/Autotag_zotero_plugin";
-      headers["HTTP-Referer"] = addonURL;
-      headers["X-OpenRouter-Title"] = "Autotag Zotero Plugin";
-    } catch (e) {
-      // Ignore if attribution headers fail
-    }
+    const addonURL = "https://github.com/LilyKun064/Autotag_zotero_plugin";
+    headers["HTTP-Referer"] = addonURL;
+    headers["X-OpenRouter-Title"] = "Autotag Zotero Plugin";
 
     const response = await Zotero.HTTP.request("POST", endpoint, {
       headers,

--- a/src/modules/llmproviders/openrouterProvider.ts
+++ b/src/modules/llmproviders/openrouterProvider.ts
@@ -1,0 +1,90 @@
+// src/modules/llmProviders/openrouterProvider.ts
+
+import type { LLMProvider } from "./LLMProvider";
+import {
+  getApiKeyForProvider,
+  getBaseUrlForProvider,
+  getCustomModelForProvider,
+  getModelForProvider,
+} from "../autotagPrefs";
+
+declare const Zotero: _ZoteroTypes.Zotero;
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export const OpenRouterProvider: LLMProvider = {
+  name: "openrouter",
+
+  async generateTags(prompt: string): Promise<string> {
+    const apiKey = getApiKeyForProvider("openrouter").trim();
+    if (!apiKey) {
+      throw new Error("OpenRouter API key not configured");
+    }
+
+    const customModel = getCustomModelForProvider("openrouter").trim();
+    const selectedModel = getModelForProvider("openrouter").trim();
+    const model = customModel || selectedModel;
+
+    if (!model) {
+      throw new Error(
+        "No OpenRouter model selected. Open Autotag settings and choose a model.",
+      );
+    }
+
+    const customBaseUrl = getBaseUrlForProvider("openrouter").trim();
+    const baseUrl = normalizeBaseUrl(customBaseUrl || "https://openrouter.ai/api/v1");
+    const endpoint = `${baseUrl}/chat/completions`;
+
+    const body = {
+      model,
+      temperature: 0.2,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a careful assistant that ALWAYS returns ONLY valid JSON.",
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+    };
+
+    // Optional attribution headers for OpenRouter rankings
+    const headers: { [key: string]: string } = {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + apiKey,
+    };
+
+    // Add optional attribution headers (these help with OpenRouter rankings)
+    try {
+      const addonURL = "https://github.com/LilyKun064/Autotag_zotero_plugin";
+      headers["HTTP-Referer"] = addonURL;
+      headers["X-OpenRouter-Title"] = "Autotag Zotero Plugin";
+    } catch (e) {
+      // Ignore if attribution headers fail
+    }
+
+    const response = await Zotero.HTTP.request("POST", endpoint, {
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    const raw = (response as any).responseText;
+    if (!raw) {
+      throw new Error("Empty OpenRouter response");
+    }
+
+    const parsed = JSON.parse(raw);
+    const content = parsed?.choices?.[0]?.message?.content;
+
+    if (!content) {
+      throw new Error("OpenRouter response missing message content");
+    }
+
+    return content;
+  },
+};

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -3,6 +3,8 @@
 /* eslint-disable */
 // @ts-nocheck
 export type FluentMessageId =
+  | 'autotag-run-menu'
+  | 'autotag-settings-menu'
   | 'item-info-row-example-label'
   | 'item-section-example1-head-text'
   | 'item-section-example1-sidenav-tooltip'

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -9,6 +9,10 @@ declare namespace _ZoteroTypes {
     PluginPrefsMap: {
       "enable": boolean;
       "input": string;
+      "apiKey.openai": string;
+      "apiKey.gemini": string;
+      "apiKey.deepseek": string;
+      "apiKey.openrouter": string;
       "baseURL.openai": string;
       "customModel.openai": string;
       "baseURL.deepseek": string;

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -13,6 +13,8 @@ declare namespace _ZoteroTypes {
       "customModel.openai": string;
       "baseURL.deepseek": string;
       "customModel.deepseek": string;
+      "baseURL.openrouter": string;
+      "customModel.openrouter": string;
     };
   }
 }


### PR DESCRIPTION
This PR includes several fixes and improvements:

- **Restore Tools menu items for Zotero 9**: Fixed menu integration by using manual DOM insertion instead of the unreliable MenuManager API
- **Add OpenRouter as LLM provider**: Added full support for OpenRouter with API key configuration and model selection
- **Fix custom model display**: Fixed settings summary and success messages to show the actual model used (custom if set, otherwise dropdown selection)
- **Add missing API key preferences**: Added missing apiKey preference definitions for all providers in prefs.js
- **Update README**: Updated documentation to reflect OpenRouter support and Zotero 9 compatibility

Changes:
- src/hooks.ts: Switched to manual menu insertion
- src/modules/autotagCore.ts: Added custom model check for success message
- src/modules/autotagPrefs.ts: Added custom model check for settings summary
- addon/prefs.js: Added API key preferences for all providers
- README.md: Updated with OpenRouter and Zotero 9 info
- typings/prefs.d.ts: Updated type definitions

This replaces the previous PR (v5.0.2) which was closed due to menu integration issues in Zotero 9.